### PR TITLE
Fix login redirect by setting authentication cookie

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -62,6 +62,7 @@ export default function DashboardPage() {
 
   const handleLogout = () => {
     localStorage.removeItem("ragster_token");
+    document.cookie = "ragster_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
     router.push("/");
   };
 

--- a/frontend/landing-page.tsx
+++ b/frontend/landing-page.tsx
@@ -85,11 +85,9 @@ export default function Component() {
       setLoginError(error);
       return;
     }
-    // Store token (e.g., localStorage or cookie)
+    // Store token client side and set auth cookie for middleware
     localStorage.setItem("ragster_token", token);
-    // Secure; FOR HTTPS
-    // document.cookie = `ragster_token=${token}; path=/;  max-age=86400`;
-    console.log(document.cookie);
+    document.cookie = `ragster_token=${token}; path=/; max-age=86400`;
     // Redirect to dashboard or show success (implement navigation as needed)
     // window.location.href = "/dashboard"; // or use next/navigation
     window.location.assign("/dashboard");


### PR DESCRIPTION
## Summary
- set auth cookie on login so dashboard middleware sees the token
- clear the auth cookie on logout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465b6b2aac8320b5eda8a80caa1252