### PR TITLE
Fix user listing error

### DIFF
--- a/backend/app/api/v1/endpoints/user.py
+++ b/backend/app/api/v1/endpoints/user.py
@@ -8,6 +8,9 @@ from app.db.session import SessionLocal
 from app.models import Role, KnowledgeBase, KnowledgeBaseUserRole
 from app.models.user import User
 from app.schemas.user import UserCreate, UserOut
+
+
+
 from app.core.security import hash_password
 from app.schemas.user_role import UserRoleOut
 from fastapi.security import OAuth2PasswordRequestForm
@@ -82,3 +85,9 @@ def get_my_roles(
         }
         for a in assignments
     ]
+
+
+@router.get("/", response_model=List[UserOut])
+def list_users(db: Session = Depends(get_db)):
+    """Return all registered users."""
+    return db.query(User).all()


### PR DESCRIPTION
## Summary
- add GET `/api/v1/user/` endpoint to list registered users

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466f4ccfdc8320bf03d759776861bf