### PR TITLE
Implement role management UI

### DIFF
--- a/frontend/app/dashboard/roles/create/page.tsx
+++ b/frontend/app/dashboard/roles/create/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function RoleCreatePage() {
+  const router = useRouter();
+  const [token, setToken] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("ragster_token");
+    if (!stored) {
+      router.push("/");
+    } else {
+      setToken(stored);
+    }
+  }, [router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    await fetch("http://localhost:8000/api/v1/role/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        name,
+        display_name: displayName,
+        description,
+      }),
+    });
+    router.push("/dashboard/roles");
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Create Role</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="displayName">Display Name</Label>
+              <Input id="displayName" value={displayName} onChange={(e) => setDisplayName(e.target.value)} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Input id="description" value={description} onChange={(e) => setDescription(e.target.value)} />
+            </div>
+            <Button type="submit" className="w-full">Create</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/Dashboard.tsx
+++ b/frontend/components/dashboard/Dashboard.tsx
@@ -237,7 +237,20 @@ export default function Dashboard({ initialSection }: { initialSection?: Section
               : "Knowledge Bases"}
           </h1>
           {activeSection === "knowledgebase" && (
-            <Button size="sm" onClick={() => router.push("/dashboard/knowledgebase/create")} className="gap-1">
+            <Button
+              size="sm"
+              onClick={() => router.push("/dashboard/knowledgebase/create")}
+              className="gap-1"
+            >
+              <Plus className="w-4 h-4" /> Add
+            </Button>
+          )}
+          {activeSection === "roles" && (
+            <Button
+              size="sm"
+              onClick={() => router.push("/dashboard/roles/create")}
+              className="gap-1"
+            >
               <Plus className="w-4 h-4" /> Add
             </Button>
           )}

--- a/frontend/components/dashboard/RoleList.tsx
+++ b/frontend/components/dashboard/RoleList.tsx
@@ -19,15 +19,46 @@ export default function RoleList({ token }: Props) {
   const [data, setData] = useState<Role[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  const fetchData = () => {
     if (!token) return;
+    setLoading(true);
     fetch("http://localhost:8000/api/v1/role/", {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((res) => res.json())
       .then(setData)
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData();
   }, [token]);
+
+  const handleEdit = async (role: Role) => {
+    if (!token) return;
+    const display_name = prompt("Display Name", role.display_name);
+    if (display_name === null) return;
+    const description = prompt("Description", role.description ?? "") ?? "";
+    await fetch(`http://localhost:8000/api/v1/role/${role.id}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ display_name, description }),
+    });
+    fetchData();
+  };
+
+  const handleDelete = async (role: Role) => {
+    if (!token) return;
+    if (!confirm("Delete this role?")) return;
+    await fetch(`http://localhost:8000/api/v1/role/${role.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    fetchData();
+  };
 
   return (
     <div className="flex-1 overflow-y-auto px-4 sm:px-8 py-8">
@@ -50,10 +81,18 @@ export default function RoleList({ token }: Props) {
                 <td className="px-4 py-2">{role.display_name}</td>
                 <td className="px-4 py-2">{role.description}</td>
                 <td className="px-4 py-2 flex items-center justify-center gap-2">
-                  <Button variant="ghost" size="icon">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleEdit(role)}
+                  >
                     <Pencil className="w-4 h-4" />
                   </Button>
-                  <Button variant="ghost" size="icon">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleDelete(role)}
+                  >
                     <Trash2 className="w-4 h-4" />
                   </Button>
                 </td>


### PR DESCRIPTION
## Summary
- add ability to create roles via new `/dashboard/roles/create` page
- show "Add" button when viewing roles
- enable editing and deleting roles on the listing page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fda34f4483209f35bc362e411aaa